### PR TITLE
Add single and multi-line comments

### DIFF
--- a/examples/count.ghost
+++ b/examples/count.ghost
@@ -1,0 +1,15 @@
+/*
+A pointless example of counting from 1 to 10.
+This is also a multiline comment that Ghost
+will completely ignore during execution.
+*/
+
+let count = function(n) {
+    if (n > 1) {
+        count(n - 1)
+    }
+
+    print(n)
+}
+
+count(10)

--- a/examples/fibtc.ghost
+++ b/examples/fibtc.ghost
@@ -10,4 +10,6 @@ let fib = function(n, a, b) {
     return fib(n - 1, b, a + b)
 }
 
-let y = fib(35, 0, 1)
+let x = fib(35, 0, 1)
+
+print("You may access the result through the variable 'x'.")

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -54,6 +54,18 @@ func (lexer *Lexer) NextToken() token.Token {
 			currentToken = newToken(token.BANG, lexer.character)
 		}
 	case '/':
+		if lexer.peekCharacter() == '/' {
+			lexer.skipMultiLineComment()
+
+			return lexer.NextToken()
+		}
+
+		if lexer.peekCharacter() == '*' {
+			lexer.skipMultiLineComment()
+
+			return lexer.NextToken()
+		}
+
 		currentToken = newToken(token.SLASH, lexer.character)
 	case '*':
 		currentToken = newToken(token.ASTERISK, lexer.character)
@@ -106,6 +118,33 @@ func (lexer *Lexer) skipWhitespace() {
 	for lexer.character == ' ' || lexer.character == '\t' || lexer.character == '\n' || lexer.character == '\r' {
 		lexer.readCharacter()
 	}
+}
+
+func (lexer *Lexer) skipSingleLineComment() {
+	for lexer.character != '\n' && lexer.character != 0 {
+		lexer.readCharacter()
+	}
+
+	lexer.skipWhitespace()
+}
+
+func (lexer *Lexer) skipMultiLineComment() {
+	endOfComment := false
+
+	for !endOfComment {
+		if lexer.character == 0 {
+			endOfComment = true
+		}
+
+		if lexer.character == '*' && lexer.peekCharacter() == '/' {
+			endOfComment = true
+			lexer.readCharacter()
+		}
+
+		lexer.readCharacter()
+	}
+
+	lexer.skipWhitespace()
 }
 
 func isLetter(character byte) bool {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -15,7 +15,7 @@ let add = function(x, y) {
 };
 
 let result = add(five, ten);
-!-/*5;
+!*-/5;
 5 < 10 > 5;
 
 if (5 < 10) {
@@ -26,9 +26,15 @@ if (5 < 10) {
 
 10 == 10;
 10 != 9;
+
+/*
+This is a multiline comment
+*/
+
 "foobar"
 "foo bar"
 [1, 2]
+// This is a single line comment
 `
 
 	tests := []struct {
@@ -72,9 +78,9 @@ if (5 < 10) {
 		{token.RPAREN, ")"},
 		{token.SEMICOLON, ";"},
 		{token.BANG, "!"},
+		{token.ASTERISK, "*"},
 		{token.MINUS, "-"},
 		{token.SLASH, "/"},
-		{token.ASTERISK, "*"},
 		{token.INT, "5"},
 		{token.SEMICOLON, ";"},
 		{token.INT, "5"},


### PR DESCRIPTION
```dart
// This is a single line comment
let a = 10 // Single line comments can be appended at the end
print(a)

/*
This is a multi-line comment.
It can span however many lines necessary.
*/
```