### PR TITLE
Add dot notation index support

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -431,6 +431,37 @@ func TestMapIndexExpressions(t *testing.T) {
 	}
 }
 
+func TestMapDotNotationExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`{"foo": 5}.foo`,
+			5,
+		},
+		{
+			`{"foo": 5}.bar`,
+			nil,
+		},
+		{
+			`{}.foo`,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		number, ok := tt.expected.(int)
+
+		if ok {
+			testNumberObject(t, evaluated, int64(number))
+		} else {
+			testNullObject(t, evaluated)
+		}
+	}
+}
+
 func TestWhileExpressions(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/examples/dot_notation.go
+++ b/examples/dot_notation.go
@@ -1,0 +1,12 @@
+let person = {
+	"name": "Turing",
+	"age": 31,
+	"hobby": "Programming"
+}
+
+print(person.name)
+print(person.age)
+
+let index = "hobby"
+
+print(person[index])

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -42,6 +42,7 @@ true and true
 true or false
 1 >= 1
 1 <= 1
+foo.bar
 // This is a single line comment
 `
 
@@ -152,6 +153,9 @@ true or false
 		{token.NUMBER, "1"},
 		{token.LTE, "<="},
 		{token.NUMBER, "1"},
+		{token.IDENTIFIER, "foo"},
+		{token.DOT, "."},
+		{token.IDENTIFIER, "bar"},
 		{token.EOF, ""},
 	}
 

--- a/parser/expression_dot_notation.go
+++ b/parser/expression_dot_notation.go
@@ -1,0 +1,14 @@
+package parser
+
+import (
+	"ghostlang.org/ghost/ast"
+	"ghostlang.org/ghost/token"
+)
+
+func (p *Parser) parseDotNotationExpression(expression ast.Expression) ast.Expression {
+	p.expectPeek(token.IDENTIFIER)
+
+	index := &ast.StringLiteral{Token: p.currentToken, Value: p.currentToken.Literal}
+
+	return &ast.IndexExpression{Left: expression, Index: index}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,6 +24,7 @@ var precedences = map[token.TokenType]int{
 	token.PERCENT:  MODULO,
 	token.LPAREN:   CALL,
 	token.LBRACKET: INDEX,
+	token.DOT:      INDEX,
 }
 
 const (
@@ -99,6 +100,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.OR, p.parseInfixExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
+	p.registerInfix(token.DOT, p.parseDotNotationExpression)
 
 	return p
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -552,6 +552,10 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 			"a % 2",
 			"(a % 2)",
 		},
+		{
+			"foo.bar * foo.baz",
+			"((foo[bar]) * (foo[baz]))",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1060,6 +1064,43 @@ func TestParsingIndexExpressions(t *testing.T) {
 
 	if !testInfixExpression(t, indexExpression.Index, 1, "+", 1) {
 		return
+	}
+}
+
+func TestParsingDotNotationExpressions(t *testing.T) {
+	input := "foo.bar"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+
+	checkParserErrors(t, p)
+
+	statement, _ := program.Statements[0].(*ast.ExpressionStatement)
+	expression, ok := statement.Expression.(*ast.IndexExpression)
+
+	if !ok {
+		t.Fatalf("expression not *ast.IndexExpression. got=%T", statement.Expression)
+	}
+
+	identifier, ok := expression.Left.(*ast.Identifier)
+
+	if !ok {
+		t.Fatalf("expression.Left not *ast.Identifier. got=%T", statement.Expression)
+	}
+
+	if !testIdentifier(t, identifier, "foo") {
+		return
+	}
+
+	index, ok := expression.Index.(*ast.StringLiteral)
+
+	if !ok {
+		t.Fatalf("expression.Index not *ast.StringLiteral. got=%T", expression.Index)
+	}
+
+	if index.Value != "bar" {
+		t.Fatalf("index.Value not 'bar'. got=%T", index.Value)
 	}
 }
 


### PR DESCRIPTION
```dart
let person = {
	"name": "Turing",
	"age": 31,
	"hobby": "Programming"
}

print(person.name)
print(person.age)

let index = "hobby"

print(person[index])
```