### PR TITLE
Add shebang support with example and fix single line comments

### DIFF
--- a/examples/comments.ghost
+++ b/examples/comments.ghost
@@ -1,0 +1,2 @@
+// This is a comment
+print("Hello world!")

--- a/examples/script
+++ b/examples/script
@@ -1,0 +1,3 @@
+#! /usr/local/bin/ghost
+
+print("hello world!")

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -53,9 +53,13 @@ func (lexer *Lexer) NextToken() token.Token {
 		} else {
 			currentToken = newToken(token.BANG, lexer.character)
 		}
+	case '#':
+		lexer.skipSingleLineComment()
+
+		return lexer.NextToken()
 	case '/':
 		if lexer.peekCharacter() == '/' {
-			lexer.skipMultiLineComment()
+			lexer.skipSingleLineComment()
 
 			return lexer.NextToken()
 		}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -24,6 +24,7 @@ if (5 < 10) {
 	return false;
 }
 
+#! \usr\bin\ghost
 10 == 10;
 10 != 9;
 
@@ -42,8 +43,8 @@ true and true
 true or false
 1 >= 1
 1 <= 1
-foo.bar
 // This is a single line comment
+foo.bar
 `
 
 	tests := []struct {

--- a/token/token.go
+++ b/token/token.go
@@ -25,6 +25,7 @@ const (
 	SLASH    = "/"
 	PERCENT  = "%"
 	DOT      = "."
+	HASH     = "#"
 
 	LT  = "<"
 	GT  = ">"


### PR DESCRIPTION
- Fixed single line comments
- Added shebang support
    ```
    nano ./hello
    ```

    ```dart
    #! /usr/local/bin/ghost

    print("hello world!")
    ```

    ```
    $ chmod +x ./hello
    $ ./hello

    Hello world!
    ```