### PR TITLE
Add ability to define default function values

### DIFF
--- a/ast/literal_function.go
+++ b/ast/literal_function.go
@@ -11,6 +11,7 @@ type FunctionLiteral struct {
 	Token      token.Token
 	Name       string
 	Parameters []*Identifier
+	Defaults   map[string]Expression
 	Body       *BlockStatement
 }
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -131,8 +131,9 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.FunctionLiteral:
 		parameters := node.Parameters
 		body := node.Body
+		defaults := node.Defaults
 		name := node.Name
-		function := &object.Function{Parameters: parameters, Env: env, Body: body}
+		function := &object.Function{Parameters: parameters, Env: env, Body: body, Defaults: defaults}
 
 		if name != "" {
 			env.Set(name, function)
@@ -565,8 +566,14 @@ func applyFunction(fn object.Object, arguments []object.Object) object.Object {
 func extendFunctionEnv(fn *object.Function, arguments []object.Object) *object.Environment {
 	env := object.NewEnclosedEnvironment(fn.Env)
 
+	for key, value := range fn.Defaults {
+		env.Set(key, Eval(value, env))
+	}
+
 	for index, parameter := range fn.Parameters {
-		env.Set(parameter.Value, arguments[index])
+		if index < len(arguments) {
+			env.Set(parameter.Value, arguments[index])
+		}
 	}
 
 	return env

--- a/examples/functions.ghost
+++ b/examples/functions.ghost
@@ -9,8 +9,15 @@ foobar := function(name = 'world', bool = false) {
     print(bool)
 }
 
+function makeCoffee(type = 'cappuccino') {
+    print('Making a cup of ' + type)
+}
+
 hello(function() {
     print("I'm an anonymous function being passed through another function!")
 })
 
 foobar()
+makeCoffee()
+makeCoffee('coffee')
+makeCoffee('espresso')

--- a/examples/functions.ghost
+++ b/examples/functions.ghost
@@ -4,8 +4,9 @@ function hello(closure) {
     closure()
 }
 
-foobar := function() {
-    print("foobar")
+foobar := function(name = 'world', bool = false) {
+    print('Hello, ' + name + '!')
+    print(bool)
 }
 
 hello(function() {

--- a/object/function.go
+++ b/object/function.go
@@ -10,6 +10,7 @@ import (
 type Function struct {
 	Parameters []*ast.Identifier
 	Body       *ast.BlockStatement
+	Defaults   map[string]ast.Expression
 	Env        *Environment
 }
 


### PR DESCRIPTION
Functions may define default values for arguments as follows:

```dart
function makeCoffee(type = 'cappuccino') {
    print('Making a cup of ' + type)
}

makeCoffee()
makeCoffee('coffee')
makeCoffee('espresso')
```

The above example will output:

```
Making a cup of cappuccino
Making a cup of coffee
Making a cup of espresso
```