### PR TITLE
Implement embeddable API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.dylib
 *.txt
 .DS_Store
-ghost
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,12 @@ GOPATH:=$(shell go env GOPATH)
 .PHONY: build test clean
 
 build: build-mac
-	@./ghost
 
 build-mac: clean
-	@go build -o ghost *.go
+	@go build -o dist/ghost *.go
 
 test:
 	@go test -v -race ./... | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''
 
 clean:
-	@rm -rf ghost
+	@rm -rf dist/ghost

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1,4 +1,4 @@
-package standard
+package builtins
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"ghostlang.org/x/ghost/object"
 )
 
+// Builtins stores a map of all registered native functions.
 var Builtins = map[string]*object.Builtin{}
 
 var (
@@ -14,10 +15,12 @@ var (
 	FALSE = &object.Boolean{Value: false}
 )
 
+// RegisterFunction registers a new native function with Ghost.
 func RegisterFunction(name string, function object.BuiltinFunction) {
 	Builtins[name] = &object.Builtin{Fn: function}
 }
 
+// NewError returns a new error object used during runtime.
 func newError(format string, a ...interface{}) *object.Error {
 	return &object.Error{Message: fmt.Sprintf(format, a...)}
 }

--- a/builtins/core.go
+++ b/builtins/core.go
@@ -1,4 +1,4 @@
-package standard
+package builtins
 
 import (
 	"bufio"

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"ghostlang.org/x/ghost/ast"
+	"ghostlang.org/x/ghost/builtins"
 	"ghostlang.org/x/ghost/decimal"
 	"ghostlang.org/x/ghost/object"
-	"ghostlang.org/x/ghost/standard"
 )
 
 var (
@@ -450,7 +450,7 @@ func evalIdentifier(node *ast.Identifier, env *object.Environment) object.Object
 		return value
 	}
 
-	if builtin, ok := standard.Builtins[node.Value]; ok {
+	if builtin, ok := builtins.Builtins[node.Value]; ok {
 		return builtin
 	}
 

--- a/ghost/ghost.go
+++ b/ghost/ghost.go
@@ -1,0 +1,49 @@
+package ghost
+
+import (
+	"fmt"
+
+	"ghostlang.org/x/ghost/builtins"
+	"ghostlang.org/x/ghost/evaluator"
+	"ghostlang.org/x/ghost/lexer"
+	"ghostlang.org/x/ghost/object"
+	"ghostlang.org/x/ghost/parser"
+)
+
+var script = Script{}
+
+// Script stores a new Ghost script source.
+type Script struct {
+	source string
+}
+
+var (
+	NULL  = &object.Null{}
+	TRUE  = &object.Boolean{Value: true}
+	FALSE = &object.Boolean{Value: false}
+)
+
+// NewScript registers a new Ghost script to be evaluated.
+func NewScript(source string) {
+	script = Script{source: source}
+}
+
+// RegisterFunction registers a new native function with Ghost.
+func RegisterFunction(name string, function object.BuiltinFunction) {
+	builtins.RegisterFunction(name, function)
+}
+
+// Evaluate runs the registered script through the Ghost evaluator.
+func Evaluate() {
+	env := object.NewEnvironment()
+	l := lexer.New(script.source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	evaluator.Eval(program, env)
+}
+
+// NewError returns a new error object used during runtime.
+func NewError(format string, a ...interface{}) *object.Error {
+	return &object.Error{Message: fmt.Sprintf(format, a...)}
+}


### PR DESCRIPTION
```go
package main

import (
	"fmt"

	"ghostlang.org/x/ghost/ghost"
	"ghostlang.org/x/ghost/object"
)

func main() {
	script := `
		print("hello world! I'm a script being ran through Ghost's embeddable API.")
		test()
	`

	ghost.RegisterFunction("test", testFunction)
	ghost.NewScript(script)
	ghost.Evaluate()
}

func testFunction(args ...object.Object) object.Object {
	fmt.Println("\nThis is called from a Go function registered with Ghost, extending the suite of available native functions.")

	return ghost.NULL
}
```