### PR TITLE
Modules

### DIFF
--- a/ast/expression_import.go
+++ b/ast/expression_import.go
@@ -1,0 +1,30 @@
+package ast
+
+import (
+	"bytes"
+	"fmt"
+
+	"ghostlang.org/x/ghost/token"
+)
+
+type ImportExpression struct {
+	Token token.Token
+	Name  Expression
+}
+
+func (ie *ImportExpression) expressionNode() {}
+
+func (ie *ImportExpression) TokenLiteral() string {
+	return ie.Token.Literal
+}
+
+func (ie *ImportExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(ie.TokenLiteral())
+	out.WriteString("(")
+	out.WriteString(fmt.Sprintf("\"%s\"", ie.Name))
+	out.WriteString(")")
+
+	return out.String()
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -136,7 +136,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		parameters := node.Parameters
 		body := node.Body
 		defaults := node.Defaults
-		name := "__function_" + node.Name
+		name := node.Name
 		function := &object.Function{Parameters: parameters, Env: env, Body: body, Defaults: defaults}
 
 		if node.Name != "" {
@@ -486,10 +486,6 @@ func evalIdentifier(node *ast.Identifier, env *object.Environment) object.Object
 
 	if builtin, ok := builtins.Builtins[node.Value]; ok {
 		return builtin
-	}
-
-	if function, ok := env.Get("__function_" + node.Value); ok {
-		return function
 	}
 
 	return newError("identifier not found: " + node.Value)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -7,6 +7,7 @@ import (
 	"ghostlang.org/x/ghost/lexer"
 	"ghostlang.org/x/ghost/object"
 	"ghostlang.org/x/ghost/parser"
+	"ghostlang.org/x/ghost/utilities"
 )
 
 func TestEvalNumberExpression(t *testing.T) {
@@ -522,6 +523,58 @@ func TestBuiltinFunctions(t *testing.T) {
 				t.Errorf("wrong error message. expected=%q, got=%q", expected, errObj.Message)
 			}
 		}
+	}
+}
+
+func TestImportExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`module := import("../stubs/module"); module.A`,
+			5,
+		},
+		{
+			`module := import("../stubs/module"); module.Sum(2, 3)`,
+			5,
+		},
+		{
+			`module := import("../stubs/module"); module.a`,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		number, ok := tt.expected.(int)
+
+		if ok {
+			testNumberObject(t, evaluated, int64(number))
+		} else {
+			testNullObject(t, evaluated)
+		}
+	}
+}
+
+func TestImportSearchPaths(t *testing.T) {
+	utilities.AddPath("../stubs")
+
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			`module := import("../stubs/module"); module.A`,
+			5,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		number, _ := tt.expected.(int)
+
+		testNumberObject(t, evaluated, int64(number))
 	}
 }
 

--- a/examples/functions.ghost
+++ b/examples/functions.ghost
@@ -1,4 +1,4 @@
-function hello(closure) {
+function Hello(closure) {
     print("Hello world!")
 
     closure()

--- a/examples/math.ghost
+++ b/examples/math.ghost
@@ -1,0 +1,15 @@
+function Add(a, b) {
+    return a + b
+}
+
+function Subtract(a, b) {
+    return a - b
+}
+
+function Multiply(a, b) {
+    return a * b
+}
+
+function Divide(a, b) {
+    return a / b
+}

--- a/examples/scratch.ghost
+++ b/examples/scratch.ghost
@@ -1,6 +1,11 @@
 math := import("examples/math")
+functions := import("examples/functions")
 
 print(math.Add(1, 2))
 print(math.Subtract(14, 4))
 print(math.Multiply(41.2, 5.32))
 print(math.Divide(933.2, 41.2))
+
+functions.Hello(function() {
+    print("Ghost")
+})

--- a/examples/scratch.ghost
+++ b/examples/scratch.ghost
@@ -1,17 +1,6 @@
-function foo() {
-    print('foo()')
+math := import("examples/math")
 
-    function bar() {
-        print('bar()')
-    }
-
-    print(identifiers())
-
-    bar()
-}
-
-// foo := true
-test := true
-
-print(identifiers())
-foo()
+print(math.Add(1, 2))
+print(math.Subtract(14, 4))
+print(math.Multiply(41.2, 5.32))
+print(math.Divide(933.2, 41.2))

--- a/examples/variables.ghost
+++ b/examples/variables.ghost
@@ -1,0 +1,9 @@
+{
+    // print(a)
+
+    a := 123
+
+    print(a)
+}
+
+// print(a)

--- a/object/environment.go
+++ b/object/environment.go
@@ -1,5 +1,7 @@
 package object
 
+import "unicode"
+
 // Environment is an object that holds a mapping of names to bound objects
 type Environment struct {
 	store map[string]Object
@@ -42,4 +44,18 @@ func (e *Environment) Set(name string, value Object) Object {
 	e.store[name] = value
 
 	return value
+}
+
+func (e *Environment) Exported() *Map {
+	pairs := make(map[MapKey]MapPair)
+
+	for k, v := range e.store {
+		// Replace this with checking for "Import" token
+		if unicode.IsUpper(rune(k[0])) {
+			s := &String{Value: k}
+			pairs[s.MapKey()] = MapPair{Key: s, Value: v}
+		}
+	}
+
+	return &Map{Pairs: pairs}
 }

--- a/object/module.go
+++ b/object/module.go
@@ -1,0 +1,16 @@
+package object
+
+import "fmt"
+
+type Module struct {
+	Name       string
+	Attributes Object
+}
+
+func (m *Module) Type() ObjectType {
+	return MODULE_OBJ
+}
+
+func (m *Module) Inspect() string {
+	return fmt.Sprintf("module(%s)", m.Name)
+}

--- a/object/object.go
+++ b/object/object.go
@@ -13,6 +13,7 @@ const (
 	NUMBER_OBJ       = "NUMBER"
 	RETURN_VALUE_OBJ = "RETURN_VALUE"
 	STRING_OBJ       = "STRING"
+	MODULE_OBJ       = "MODULE"
 )
 
 type Object interface {

--- a/parser/expression_import.go
+++ b/parser/expression_import.go
@@ -1,0 +1,24 @@
+package parser
+
+import (
+	"ghostlang.org/x/ghost/ast"
+	"ghostlang.org/x/ghost/token"
+)
+
+func (p *Parser) parseImportExpression() ast.Expression {
+	expression := &ast.ImportExpression{Token: p.currentToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	p.nextToken()
+
+	expression.Name = p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	return expression
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -92,6 +92,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LBRACKET, p.parseListLiteral)
 	p.registerPrefix(token.LBRACE, p.parseMapLiteral)
 	p.registerPrefix(token.WHILE, p.parseWhileExpression)
+	p.registerPrefix(token.IMPORT, p.parseImportExpression)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -441,6 +441,32 @@ func TestParsingPostfixExpressions(t *testing.T) {
 	}
 }
 
+func TestParsingImportExpressions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			`import("foobar")`,
+			`import("foobar")`,
+		},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+
+		checkParserErrors(t, p)
+
+		actual := program.String()
+
+		if actual != tt.expected {
+			t.Errorf("expected=%q, got=%q", tt.expected, actual)
+		}
+	}
+}
+
 func TestOperatorPrecedenceParsing(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/stubs/module.ghost
+++ b/stubs/module.ghost
@@ -1,0 +1,6 @@
+a := 1
+A := 5
+
+Sum := function(a, b) {
+    return a + b
+}

--- a/token/token.go
+++ b/token/token.go
@@ -52,6 +52,8 @@ const (
 	WHILE    = "WHILE"
 	AND      = "AND"
 	OR       = "OR"
+	EXPORT   = "EXPORT"
+	IMPORT   = "IMPORT"
 
 	EQ    = "=="
 	NOTEQ = "!="
@@ -76,6 +78,8 @@ var keywords = map[string]TokenType{
 	"while":    WHILE,
 	"and":      AND,
 	"or":       OR,
+	"export":   EXPORT,
+	"import":   IMPORT,
 }
 
 // LookupIdentifier checks the `keywords` table to see whether

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -1,0 +1,62 @@
+package utilities
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var SearchPaths []string
+
+func init() {
+	cwd, err := os.Getwd()
+
+	if err != nil {
+		log.Fatalf("error getting cwd: %s", err)
+	}
+
+	if e := os.Getenv("GHOSTPATH"); e != "" {
+		tokens := strings.Split(e, ":")
+
+		for _, token := range tokens {
+			AddPath(token)
+		}
+	} else {
+		SearchPaths = append(SearchPaths, cwd)
+	}
+}
+
+func AddPath(path string) error {
+	path = os.ExpandEnv(filepath.Clean(path))
+	absolutePath, err := filepath.Abs(path)
+
+	if err != nil {
+		return err
+	}
+
+	SearchPaths = append(SearchPaths, absolutePath)
+
+	return nil
+}
+
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+
+	return err == nil
+}
+
+func FindModule(name string) string {
+	basename := fmt.Sprintf("%s.ghost", name)
+
+	for _, p := range SearchPaths {
+		filename := filepath.Join(p, basename)
+
+		if Exists(filename) {
+			return filename
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
Adds in simple support for importable modules. Implementation was gleaned from Prologic's implementation [here](https://github.com/prologic/monkey-lang/pull/6).

Additional work to be done:
- [ ] Only import new modules; if a module was previous imported, it can be skipped
- [ ] Add in the `export` keyword vs. importing by Uppercase identifiers:
    ```dart
    export function add(a, b) {
        return a + b
    }
    ```
- [ ] Add the working directory path of the _script_ being ran to the list of module search paths by default