### PR TITLE
Add range operator (..)

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -396,8 +396,8 @@ func evalNumberInfixExpression(node *ast.InfixExpression, operator string, left 
 			return utilities.NewError("Variable %s is unknown", node.Left.String())
 		}
 
-		decimal := &object.Number{Value: leftValue.Add(rightValue)}
-		env.Set(node.Left.String(), decimal)
+		dec := &object.Number{Value: leftValue.Add(rightValue)}
+		env.Set(node.Left.String(), dec)
 
 		return value.NULL
 	case "-=":
@@ -407,8 +407,8 @@ func evalNumberInfixExpression(node *ast.InfixExpression, operator string, left 
 			return utilities.NewError("Variable %s is unknown", node.Left.String())
 		}
 
-		decimal := &object.Number{Value: leftValue.Sub(rightValue)}
-		env.Set(node.Left.String(), decimal)
+		dec := &object.Number{Value: leftValue.Sub(rightValue)}
+		env.Set(node.Left.String(), dec)
 
 		return value.NULL
 	case "*=":
@@ -418,8 +418,8 @@ func evalNumberInfixExpression(node *ast.InfixExpression, operator string, left 
 			return utilities.NewError("Variable %s is unknown", node.Left.String())
 		}
 
-		decimal := &object.Number{Value: leftValue.Mul(rightValue)}
-		env.Set(node.Left.String(), decimal)
+		dec := &object.Number{Value: leftValue.Mul(rightValue)}
+		env.Set(node.Left.String(), dec)
 
 		return value.NULL
 	case "/=":
@@ -429,10 +429,26 @@ func evalNumberInfixExpression(node *ast.InfixExpression, operator string, left 
 			return utilities.NewError("Variable %s is unknown", node.Left.String())
 		}
 
-		decimal := &object.Number{Value: leftValue.Div(rightValue)}
-		env.Set(node.Left.String(), decimal)
+		dec := &object.Number{Value: leftValue.Div(rightValue)}
+		env.Set(node.Left.String(), dec)
 
 		return value.NULL
+	case "..":
+		numbers := make([]object.Object, 0)
+		one := decimal.NewFromInt(1)
+		num := leftValue
+
+		for {
+			numbers = append(numbers, &object.Number{Value: num})
+
+			if num.GreaterThanOrEqual(rightValue) {
+				break
+			}
+
+			num = num.Add(one)
+		}
+
+		return &object.List{Elements: numbers}
 	default:
 		return utilities.NewError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -68,6 +68,44 @@ func TestLogicalOperators(t *testing.T) {
 	}
 }
 
+func TestDecimal(t *testing.T) {
+	dec1 := decimal.NewFromInt(1)
+	dec2 := decimal.NewFromInt(1)
+
+	t.Logf("%v", dec1.LessThanOrEqual(dec2))
+}
+
+func TestRangeOperators(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// {`1 .. 0`, []int{}},
+		// {`-1 .. 0`, []int{-1, 0}},
+		// {`1 .. 1`, []int{1}},
+		{`1 .. 5`, []int{1, 2, 3, 4, 5}},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch expected := tt.expected.(type) {
+		case []int:
+			list, ok := evaluated.(*object.List)
+
+			if !ok {
+				t.Errorf("object not List. got=%T (%+v)", evaluated, evaluated)
+				continue
+			}
+
+			if len(list.Elements) != len(expected) {
+				t.Errorf("wrong number of elements. want=%d, got=%d", len(expected), len(list.Elements))
+				continue
+			}
+		}
+	}
+}
+
 func TestEvalBooleanExpression(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -153,7 +153,14 @@ func (lexer *Lexer) NextToken() token.Token {
 		currentToken.Type = token.STRING
 		currentToken.Literal = lexer.readString('\'')
 	case '.':
-		currentToken = newToken(token.DOT, lexer.character)
+		if lexer.peekCharacter() == '.' {
+			character := lexer.character
+			lexer.readCharacter()
+			literal := string(character) + string(lexer.character)
+			currentToken = token.Token{Type: token.RANGE, Literal: literal}
+		} else {
+			currentToken = newToken(token.DOT, lexer.character)
+		}
 	case 0:
 		currentToken.Type = token.EOF
 		currentToken.Literal = ""

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -52,6 +52,7 @@ index += 10
 index -= 10
 index *= 10
 index /= 10
+1 .. 10
 `
 
 	tests := []struct {
@@ -176,6 +177,9 @@ index /= 10
 		{token.NUMBER, "10"},
 		{token.IDENTIFIER, "index"},
 		{token.SLASHASSIGN, "/="},
+		{token.NUMBER, "10"},
+		{token.NUMBER, "1"},
+		{token.RANGE, ".."},
 		{token.NUMBER, "10"},
 		{token.EOF, ""},
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,6 +31,7 @@ var precedences = map[token.TokenType]int{
 	token.LPAREN:         CALL,
 	token.LBRACKET:       INDEX,
 	token.DOT:            INDEX,
+	token.RANGE:          RANGE,
 }
 
 const (
@@ -39,6 +40,7 @@ const (
 	ASSIGN
 	OR
 	AND
+	RANGE
 	EQUALS
 	LESSGREATER
 	SUM
@@ -118,6 +120,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
 	p.registerInfix(token.DOT, p.parseDotNotationExpression)
+	p.registerInfix(token.RANGE, p.parseInfixExpression)
 
 	p.postfixParseFns = make(map[token.TokenType]postfixParseFn)
 	p.registerPostfix(token.PLUSPLUS, p.parsePostfixExpression)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -378,6 +378,7 @@ func TestParsingInfixExpressions(t *testing.T) {
 		{"false == false", false, "==", false},
 		{"true and true", true, "and", true},
 		{"true or false", true, "or", false},
+		{"1 .. 10", 1, "..", 10},
 	}
 
 	for _, tt := range infixTests {

--- a/token/token.go
+++ b/token/token.go
@@ -74,6 +74,8 @@ const (
 
 	PLUSPLUS   = "++"
 	MINUSMINUS = "--"
+
+	RANGE = ".."
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
Implemented a range operator (`..`) - behind the scenes this generates a list containing the numeric values of the defined range:

```go
range := 1 .. 10

// [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

A blog post was written detailing the implementation [here](https://ghostlang.org/blog/2020/10/implementing-a-range-operator-into-ghost) as well :+1: