### PR TITLE
Add object method evaluation + string methods

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -161,6 +161,13 @@ type (
 		Condition   Expression
 		Consequence *BlockStatement
 	}
+
+	// MethodCallExpression defines a new expression type for defining method call expressions.
+	MethodCallExpression struct {
+		Token  token.Token
+		Object Expression
+		Call   Expression
+	}
 )
 
 // ----------------------------------------------------------------------------
@@ -212,18 +219,19 @@ type (
 // expressionNode() ensures that only expression/literal nodes
 // can be assigned to an Expression.
 //
-func (ce *CallExpression) expressionNode()     {}
-func (fe *ForExpression) expressionNode()      {}
-func (fie *ForInExpression) expressionNode()   {}
-func (ie *IfExpression) expressionNode()       {}
-func (ie *ImportExpression) expressionNode()   {}
-func (ie *IndexExpression) expressionNode()    {}
-func (ie *InfixExpression) expressionNode()    {}
-func (me *MethodExpression) expressionNode()   {}
-func (pe *PostfixExpression) expressionNode()  {}
-func (pe *PrefixExpression) expressionNode()   {}
-func (pe *PropertyExpression) expressionNode() {}
-func (we *WhileExpression) expressionNode()    {}
+func (ce *CallExpression) expressionNode()        {}
+func (fe *ForExpression) expressionNode()         {}
+func (fie *ForInExpression) expressionNode()      {}
+func (ie *IfExpression) expressionNode()          {}
+func (ie *ImportExpression) expressionNode()      {}
+func (ie *IndexExpression) expressionNode()       {}
+func (ie *InfixExpression) expressionNode()       {}
+func (me *MethodExpression) expressionNode()      {}
+func (pe *PostfixExpression) expressionNode()     {}
+func (pe *PrefixExpression) expressionNode()      {}
+func (pe *PropertyExpression) expressionNode()    {}
+func (we *WhileExpression) expressionNode()       {}
+func (mce *MethodCallExpression) expressionNode() {}
 
 func (bl *BooleanLiteral) expressionNode()    {}
 func (fl *FunctionLiteral) expressionNode()   {}
@@ -235,18 +243,19 @@ func (sl *StringLiteral) expressionNode()     {}
 
 // TokenLiteral and String implementations for expression/literal nodes.
 //
-func (ce *CallExpression) TokenLiteral() string     { return ce.Token.Literal }
-func (fe *ForExpression) TokenLiteral() string      { return fe.Token.Literal }
-func (fie *ForInExpression) TokenLiteral() string   { return fie.Token.Literal }
-func (ie *IfExpression) TokenLiteral() string       { return ie.Token.Literal }
-func (ie *ImportExpression) TokenLiteral() string   { return ie.Token.Literal }
-func (ie *IndexExpression) TokenLiteral() string    { return ie.Token.Literal }
-func (ie *InfixExpression) TokenLiteral() string    { return ie.Token.Literal }
-func (me *MethodExpression) TokenLiteral() string   { return me.Token.Literal }
-func (pe *PostfixExpression) TokenLiteral() string  { return pe.Token.Literal }
-func (pe *PrefixExpression) TokenLiteral() string   { return pe.Token.Literal }
-func (pe *PropertyExpression) TokenLiteral() string { return pe.Token.Literal }
-func (we *WhileExpression) TokenLiteral() string    { return we.Token.Literal }
+func (ce *CallExpression) TokenLiteral() string        { return ce.Token.Literal }
+func (fe *ForExpression) TokenLiteral() string         { return fe.Token.Literal }
+func (fie *ForInExpression) TokenLiteral() string      { return fie.Token.Literal }
+func (ie *IfExpression) TokenLiteral() string          { return ie.Token.Literal }
+func (ie *ImportExpression) TokenLiteral() string      { return ie.Token.Literal }
+func (ie *IndexExpression) TokenLiteral() string       { return ie.Token.Literal }
+func (ie *InfixExpression) TokenLiteral() string       { return ie.Token.Literal }
+func (me *MethodExpression) TokenLiteral() string      { return me.Token.Literal }
+func (pe *PostfixExpression) TokenLiteral() string     { return pe.Token.Literal }
+func (pe *PrefixExpression) TokenLiteral() string      { return pe.Token.Literal }
+func (pe *PropertyExpression) TokenLiteral() string    { return pe.Token.Literal }
+func (we *WhileExpression) TokenLiteral() string       { return we.Token.Literal }
+func (mce *MethodCallExpression) TokenLiteral() string { return mce.Token.Literal }
 
 func (bl *BooleanLiteral) TokenLiteral() string    { return bl.Token.Literal }
 func (fl *FunctionLiteral) TokenLiteral() string   { return fl.Token.Literal }
@@ -417,6 +426,16 @@ func (we *WhileExpression) String() string {
 	out.WriteString(we.Condition.String())
 	out.WriteString(" ")
 	out.WriteString(we.Consequence.String())
+
+	return out.String()
+}
+
+func (mce *MethodCallExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(mce.Object.String())
+	out.WriteString(".")
+	out.WriteString(mce.Call.String())
 
 	return out.String()
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -161,13 +161,6 @@ type (
 		Condition   Expression
 		Consequence *BlockStatement
 	}
-
-	// MethodCallExpression defines a new expression type for defining method call expressions.
-	MethodCallExpression struct {
-		Token  token.Token
-		Object Expression
-		Call   Expression
-	}
 )
 
 // ----------------------------------------------------------------------------
@@ -219,19 +212,18 @@ type (
 // expressionNode() ensures that only expression/literal nodes
 // can be assigned to an Expression.
 //
-func (ce *CallExpression) expressionNode()        {}
-func (fe *ForExpression) expressionNode()         {}
-func (fie *ForInExpression) expressionNode()      {}
-func (ie *IfExpression) expressionNode()          {}
-func (ie *ImportExpression) expressionNode()      {}
-func (ie *IndexExpression) expressionNode()       {}
-func (ie *InfixExpression) expressionNode()       {}
-func (me *MethodExpression) expressionNode()      {}
-func (pe *PostfixExpression) expressionNode()     {}
-func (pe *PrefixExpression) expressionNode()      {}
-func (pe *PropertyExpression) expressionNode()    {}
-func (we *WhileExpression) expressionNode()       {}
-func (mce *MethodCallExpression) expressionNode() {}
+func (ce *CallExpression) expressionNode()     {}
+func (fe *ForExpression) expressionNode()      {}
+func (fie *ForInExpression) expressionNode()   {}
+func (ie *IfExpression) expressionNode()       {}
+func (ie *ImportExpression) expressionNode()   {}
+func (ie *IndexExpression) expressionNode()    {}
+func (ie *InfixExpression) expressionNode()    {}
+func (me *MethodExpression) expressionNode()   {}
+func (pe *PostfixExpression) expressionNode()  {}
+func (pe *PrefixExpression) expressionNode()   {}
+func (pe *PropertyExpression) expressionNode() {}
+func (we *WhileExpression) expressionNode()    {}
 
 func (bl *BooleanLiteral) expressionNode()    {}
 func (fl *FunctionLiteral) expressionNode()   {}
@@ -243,19 +235,18 @@ func (sl *StringLiteral) expressionNode()     {}
 
 // TokenLiteral and String implementations for expression/literal nodes.
 //
-func (ce *CallExpression) TokenLiteral() string        { return ce.Token.Literal }
-func (fe *ForExpression) TokenLiteral() string         { return fe.Token.Literal }
-func (fie *ForInExpression) TokenLiteral() string      { return fie.Token.Literal }
-func (ie *IfExpression) TokenLiteral() string          { return ie.Token.Literal }
-func (ie *ImportExpression) TokenLiteral() string      { return ie.Token.Literal }
-func (ie *IndexExpression) TokenLiteral() string       { return ie.Token.Literal }
-func (ie *InfixExpression) TokenLiteral() string       { return ie.Token.Literal }
-func (me *MethodExpression) TokenLiteral() string      { return me.Token.Literal }
-func (pe *PostfixExpression) TokenLiteral() string     { return pe.Token.Literal }
-func (pe *PrefixExpression) TokenLiteral() string      { return pe.Token.Literal }
-func (pe *PropertyExpression) TokenLiteral() string    { return pe.Token.Literal }
-func (we *WhileExpression) TokenLiteral() string       { return we.Token.Literal }
-func (mce *MethodCallExpression) TokenLiteral() string { return mce.Token.Literal }
+func (ce *CallExpression) TokenLiteral() string     { return ce.Token.Literal }
+func (fe *ForExpression) TokenLiteral() string      { return fe.Token.Literal }
+func (fie *ForInExpression) TokenLiteral() string   { return fie.Token.Literal }
+func (ie *IfExpression) TokenLiteral() string       { return ie.Token.Literal }
+func (ie *ImportExpression) TokenLiteral() string   { return ie.Token.Literal }
+func (ie *IndexExpression) TokenLiteral() string    { return ie.Token.Literal }
+func (ie *InfixExpression) TokenLiteral() string    { return ie.Token.Literal }
+func (me *MethodExpression) TokenLiteral() string   { return me.Token.Literal }
+func (pe *PostfixExpression) TokenLiteral() string  { return pe.Token.Literal }
+func (pe *PrefixExpression) TokenLiteral() string   { return pe.Token.Literal }
+func (pe *PropertyExpression) TokenLiteral() string { return pe.Token.Literal }
+func (we *WhileExpression) TokenLiteral() string    { return we.Token.Literal }
 
 func (bl *BooleanLiteral) TokenLiteral() string    { return bl.Token.Literal }
 func (fl *FunctionLiteral) TokenLiteral() string   { return fl.Token.Literal }
@@ -426,16 +417,6 @@ func (we *WhileExpression) String() string {
 	out.WriteString(we.Condition.String())
 	out.WriteString(" ")
 	out.WriteString(we.Consequence.String())
-
-	return out.String()
-}
-
-func (mce *MethodCallExpression) String() string {
-	var out bytes.Buffer
-
-	out.WriteString(mce.Object.String())
-	out.WriteString(".")
-	out.WriteString(mce.Call.String())
 
 	return out.String()
 }

--- a/builtins/core.go
+++ b/builtins/core.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"ghostlang.org/x/ghost/error"
 	"ghostlang.org/x/ghost/object"
@@ -21,7 +20,6 @@ func init() {
 	RegisterFunction("identifiers", identifiersFunction)
 	RegisterFunction("input", inputFunction)
 	RegisterFunction("last", lastFunction)
-	RegisterFunction("length", lengthFunction)
 	RegisterFunction("number", numberFunction)
 	RegisterFunction("print", printFunction)
 	RegisterFunction("push", pushFunction)
@@ -122,21 +120,6 @@ func lastFunction(env *object.Environment, line int, args ...object.Object) obje
 	length := len(list.Elements)
 
 	return list.Elements[length-1]
-}
-
-func lengthFunction(env *object.Environment, line int, args ...object.Object) object.Object {
-	if len(args) != 1 {
-		return error.NewError(line, error.WrongNumberArguments, len(args), 1)
-	}
-
-	switch arg := args[0].(type) {
-	case *object.List:
-		return &object.Number{Value: decimal.NewFromInt(int64(len(arg.Elements)))}
-	case *object.String:
-		return &object.Number{Value: decimal.NewFromInt(int64(utf8.RuneCountInString(arg.Value)))}
-	default:
-		return error.NewError(line, error.ArgumentMustBe, "first", "length", "LIST or STRING", args[0].Type())
-	}
 }
 
 func numberFunction(env *object.Environment, line int, args ...object.Object) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -789,8 +789,6 @@ func evalMethodExpression(me *ast.MethodExpression, env *object.Environment) obj
 	}
 
 	return obj.CallMethod(me.Method.String(), args)
-
-	// return applyMethod(me.Token, obj, me, env, args)
 }
 
 func applyFunction(tok token.Token, fn object.Object, env *object.Environment, arguments []object.Object) object.Object {
@@ -809,18 +807,6 @@ func applyFunction(tok token.Token, fn object.Object, env *object.Environment, a
 	default:
 		return error.NewError(tok.Line, error.NotAFunction, fn.Type())
 	}
-}
-
-func applyMethod(tok token.Token, obj object.Object, me *ast.MethodExpression, env *object.Environment, args []object.Object) object.Object {
-	method := me.Method.String()
-
-	mapObject, _ := obj.(*object.Map)
-
-	// if isMapObject && mapObject.GetKeyType(method) == object.FUNCTION_OBJ {
-	pair, _ := mapObject.GetPair(method)
-
-	return applyFunction(tok, pair.Value.(*object.Function), env, args)
-	// }
 }
 
 func extendFunctionEnv(fn *object.Function, arguments []object.Object) *object.Environment {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -43,19 +43,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 
 		return value.NULL
 	case *ast.MethodExpression:
-		obj := Eval(node.Object, env)
-
-		if error.IsError(obj) {
-			return obj
-		}
-
-		args := evalExpressions(node.Arguments, env)
-
-		if len(args) == 1 && error.IsError(args[0]) {
-			return args[0]
-		}
-
-		return applyMethod(node.Token, obj, node, env, args)
+		return evalMethodExpression(node, env)
 	case *ast.PropertyExpression:
 		return evalPropertyExpression(node, env)
 	case *ast.IfExpression:
@@ -785,6 +773,24 @@ func evalPropertyAssignment(pe *ast.PropertyExpression, val object.Object, env *
 	}
 
 	return error.NewError(pe.Token.Line, error.InvalidPropertyAssignment, pe.Token.Literal, leftObj.Type())
+}
+
+func evalMethodExpression(me *ast.MethodExpression, env *object.Environment) object.Object {
+	obj := Eval(me.Object, env)
+
+	if error.IsError(obj) {
+		return obj
+	}
+
+	args := evalExpressions(me.Arguments, env)
+
+	if len(args) == 1 && error.IsError(args[0]) {
+		return args[0]
+	}
+
+	return obj.CallMethod(me.Method.String(), args)
+
+	// return applyMethod(me.Token, obj, me, env, args)
 }
 
 func applyFunction(tok token.Token, fn object.Object, env *object.Environment, arguments []object.Object) object.Object {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -577,7 +577,7 @@ func TestForExpressions(t *testing.T) {
 	}{
 		{`x := 1; for (x := 0; x < 10; x := x + 1) { x }; x;`, 1},
 		{`for (i := 0; i < 10; i := i + 1) { i };`, nil},
-		{`y := []; for (x in 1 .. 10) { push(y, x) }; length(y)`, 10},
+		{`y := []; for (x in 1 .. 10) { push(y, x) }; y.length()`, 10},
 		{`y := []; x := 100 for (x in 1 .. 10) { x := x + 1 }; x`, 100},
 	}
 
@@ -593,16 +593,16 @@ func TestForExpressions(t *testing.T) {
 	}
 }
 
-func TestBuiltinFunctions(t *testing.T) {
+func TestLengthMethod(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
 	}{
-		{`length("")`, 0},
-		{`length("four")`, 4},
-		{`length("hello world")`, 11},
-		{`length(1)`, "first argument to 'length' must be LIST or STRING, got NUMBER on line 1"},
-		{`length("one", "two")`, "wrong number of arguments: 2 while expected: 1 on line 1"},
+		{`"".length()`, 0},
+		{`"four".length()`, 4},
+		{`"hello world".length()`, 11},
+		{`[1].length()`, 1},
+		{`{'foo': 0, 'bar': 1}.length()`, 2},
 	}
 
 	for _, tt := range tests {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,6 +1,8 @@
 package object
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestObjectMapKey(t *testing.T) {
 	hello1 := &String{Value: "Hello World"}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1266,6 +1266,29 @@ func TestForExpression(t *testing.T) {
 	}
 }
 
+func TestMethodCallExpression(t *testing.T) {
+	input := "[1, 2, 3].length()"
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain 1 statement. got=%d", len(program.Statements))
+	}
+
+	statement := program.Statements[0].(*ast.ExpressionStatement)
+	method, ok := statement.Expression.(*ast.MethodExpression)
+
+	if !ok {
+		t.Fatalf("expression not *ast.MethodExpression. got=%T (%+v)", statement.Expression, statement.Expression)
+	}
+
+	_ = method
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 import "fmt"
 
 var (
-	Version = "0.9.0"
+	Version = "0.10.0"
 )
 
 func String() string {


### PR DESCRIPTION
- Added callable object methods
- Added first pass of string methods:
  - `string.toLowerCase()`
  - `string.toUpperCase()`
  - `string.toString()`
  - `string.toNumber()`
  - `string.trim()`
  - `string.trimEnd()`
  - `string.trimStart()`
  - `string.length()`
- Bumped version to `0.10.0`