### PR TITLE
Add default case to switch statements

### DIFF
--- a/evaluator/switch.go
+++ b/evaluator/switch.go
@@ -10,6 +10,11 @@ func evaluateSwitch(node *ast.Switch, scope *object.Scope) object.Object {
 	obj := Evaluate(node.Value, scope)
 
 	for _, option := range node.Cases {
+		// Skip default case to handle last if needed
+		if option.Default {
+			continue
+		}
+
 		for _, val := range option.Value {
 			out := Evaluate(val, scope)
 
@@ -19,6 +24,15 @@ func evaluateSwitch(node *ast.Switch, scope *object.Scope) object.Object {
 
 				return out
 			}
+		}
+	}
+
+	// Handle default case
+	for _, option := range node.Cases {
+		if option.Default {
+			out := evaluateBlock(option.Body, scope)
+
+			return out
 		}
 	}
 

--- a/examples/switch.ghost
+++ b/examples/switch.ghost
@@ -1,25 +1,16 @@
-// value = true
-
-// switch (value) {
-//     case false {
-//         print("false.")
-//     }
-
-//     case true {
-//         print("true.")
-//     }
-// }
-
-beverage = "coffee"
+beverage = "tea"
 
 switch (beverage) {
-    case "water" {
-        print("Water is $0.75 per bottle.")
-    }
-    case "juice" {
-        print("Juice is $1.25 per bottle.")
-    }
-    case "coffee", "latte" {
-        print("Coffee and lattes are $2.75 per 12oz.")
-    }
+  case "water" {
+    print("Water is $0.75 per bottle.")
+  }
+  case "juice" {
+    print("Juice is $1.25 per bottle.")
+  }
+  case "coffee", "latte" {
+    print("Coffee and lattes are $2.75 per 12oz.")
+  }
+  default {
+    print("Unknown beverage.")
+  }
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -766,6 +766,101 @@ func TestReturnStatements(t *testing.T) {
 	}
 }
 
+func TestSwitchStatements(t *testing.T) {
+	input := `switch (value) {
+		case 1 {
+			print('one')
+		}
+		case 2 {
+			print('two')
+		}
+	}`
+
+	scanner := scanner.New(input, "test.ghost")
+	parser := New(scanner)
+	program := parser.Parse()
+
+	failIfParserHasErrors(t, parser)
+
+	statement, ok := program.Statements[0].(*ast.Expression)
+
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.Expression. got=%T", program.Statements[0])
+	}
+
+	switchStatement, ok := statement.Expression.(*ast.Switch)
+
+	if !ok {
+		t.Fatalf("statement is not ast.Switch. got=%T", statement.Expression)
+	}
+
+	if len(switchStatement.Cases) != 2 {
+		t.Fatalf("switchStatement.Cases has wrong length. got=%d", len(switchStatement.Cases))
+	}
+}
+
+func TestSwitchStatementsWithDefault(t *testing.T) {
+	input := `switch (value) {
+		case 1 {
+			print('one')
+		}
+		case 2 {
+			print('two')
+		}
+		default {
+			print('default')
+		}
+	}`
+
+	scanner := scanner.New(input, "test.ghost")
+	parser := New(scanner)
+	program := parser.Parse()
+
+	failIfParserHasErrors(t, parser)
+
+	statement, ok := program.Statements[0].(*ast.Expression)
+
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.Expression. got=%T", program.Statements[0])
+	}
+
+	switchStatement, ok := statement.Expression.(*ast.Switch)
+
+	if !ok {
+		t.Fatalf("statement is not ast.Switch. got=%T", statement.Expression)
+	}
+
+	if len(switchStatement.Cases) != 3 {
+		t.Fatalf("switchStatement.Cases has wrong length. got=%d", len(switchStatement.Cases))
+	}
+}
+
+func TestSwitchStatementsWithMultipleDefaults(t *testing.T) {
+	input := `switch (value) {
+		case 1 {
+			print('one')
+		}
+		case 2 {
+			print('two')
+		}
+		case default {
+			print('default one')
+		}
+		default {
+			print('default two')
+		}
+	}`
+
+	scanner := scanner.New(input, "test.ghost")
+	parser := New(scanner)
+	parser.Parse()
+
+	// Expecting a parser error here for having multiple defaults
+	if len(parser.Errors()) != 1 {
+		t.Fatalf("parser should have 1 error. got=%d", len(parser.Errors()))
+	}
+}
+
 // =============================================================================
 // Helper methods
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -25,6 +25,7 @@ var keywords = map[string]token.Type{
 	"case":     token.CASE,
 	"class":    token.CLASS,
 	"continue": token.CONTINUE,
+	"default":  token.DEFAULT,
 	"else":     token.ELSE,
 	"extends":  token.EXTENDS,
 	"false":    token.FALSE,

--- a/token/token.go
+++ b/token/token.go
@@ -65,6 +65,7 @@ const (
 	CASE     = "case"
 	CLASS    = "class"
 	CONTINUE = "continue"
+	DEFAULT  = "default"
 	ELSE     = "else"
 	EXTENDS  = "extends"
 	FALSE    = "false"


### PR DESCRIPTION
## What does this implement or fix?
### Added
- Added ability to define a `default` case to `switch` statements
- Added parser tests for switch statements

```typescript
switch(value) {
  case true {
    // handle true case
  }

  case false {
    // handle false case
  }

  default {
    // handle default case
  }
}
```

## Additional Notes
Thanks to @skx and https://github.com/skx/monkey/pull/71 for an example on an implementation 👍🏻 