### PR TITLE
fix this keyword reference outside of classes

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -372,6 +372,37 @@ func TestInheritedProperties(t *testing.T) {
 	}
 }
 
+func TestThisOutsideClass(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "this at top level",
+			input:    `this`,
+			expected: "1:1:test.ghost: runtime error: 'this' used outside of class context",
+		},
+		{
+			name:     "this in regular function",
+			input:    `function foo() { return this } foo()`,
+			expected: "1:25:test.ghost: runtime error: 'this' used outside of class context",
+		},
+		{
+			name:     "this.property at top level",
+			input:    `this.name`,
+			expected: "1:1:test.ghost: runtime error: 'this' used outside of class context",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluate(tt.input)
+			isErrorObject(t, result, tt.expected)
+		})
+	}
+}
+
 // =============================================================================
 // Helper functions
 

--- a/evaluator/this.go
+++ b/evaluator/this.go
@@ -6,11 +6,10 @@ import (
 )
 
 func evaluateThis(node *ast.This, scope *object.Scope) object.Object {
-	if scope.Self != nil {
+	switch scope.Self.(type) {
+	case *object.Instance, *object.Class:
 		return scope.Self
 	}
 
-	pairs := make(map[object.MapKey]object.MapPair)
-
-	return &object.Map{Pairs: pairs}
+	return newError("%d:%d:%s: runtime error: 'this' used outside of class context", node.Token.Line, node.Token.Column, node.Token.File)
 }


### PR DESCRIPTION
## What does this implement or fix?

### Fixed
- Fixed `this` keyword now returns a runtime error when used outside of class context instead of silently returning an empty map
- Fixed `this` in regular functions now correctly errors instead of returning the function object