### PR TITLE
Added support for comma-separated traits in use statement

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -297,6 +297,36 @@ func TestTraitMethodLookup(t *testing.T) {
 			`,
 			expected: 30,
 		},
+		{
+			name: "comma-separated traits",
+			input: `
+				trait First {
+					function first() {
+						return 1
+					}
+				}
+
+				trait Second {
+					function second() {
+						return 2
+					}
+				}
+
+				trait Third {
+					function third() {
+						return 3
+					}
+				}
+
+				class Thing {
+					use First, Second, Third
+				}
+
+				t = Thing.new()
+				t.first() + t.second() + t.third()
+			`,
+			expected: 6,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parser/use.go
+++ b/parser/use.go
@@ -13,8 +13,19 @@ func (parser *Parser) useExpression() ast.ExpressionNode {
 	}
 
 	identifier := &ast.Identifier{Token: parser.currentToken, Value: parser.currentToken.Lexeme}
-
 	use.Traits = append(use.Traits, identifier)
+
+	for parser.nextTokenIs(token.COMMA) {
+		parser.readToken() // consume comma
+
+		if !parser.expectNextTokenIs(token.IDENTIFIER) {
+			return nil
+		}
+
+		identifier := &ast.Identifier{Token: parser.currentToken, Value: parser.currentToken.Lexeme}
+
+		use.Traits = append(use.Traits, identifier)
+	}
 
 	return use
 }


### PR DESCRIPTION
## What does this implement or fix?
### Added
- Added support for comma-separated traits in `use` statements (e.g., `use Foo, Bar, Baz`)