### PR TITLE
Fixed inherited constructor invocation for subclasses

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -402,6 +402,79 @@ func TestInheritedProperties(t *testing.T) {
 	}
 }
 
+func TestInheritedConstructor(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{
+			name: "parent constructor called when child has none",
+			input: `
+				class Animal {
+					function constructor(legs) {
+						this.legs = legs
+					}
+				}
+
+				class Dog extends Animal {
+				}
+
+				d = Dog.new(4)
+				d.legs
+			`,
+			expected: 4,
+		},
+		{
+			name: "grandparent constructor called when child and parent have none",
+			input: `
+				class Animal {
+					function constructor(legs) {
+						this.legs = legs
+					}
+				}
+
+				class Mammal extends Animal {
+				}
+
+				class Dog extends Mammal {
+				}
+
+				d = Dog.new(4)
+				d.legs
+			`,
+			expected: 4,
+		},
+		{
+			name: "child constructor overrides parent",
+			input: `
+				class Animal {
+					function constructor(legs) {
+						this.legs = legs
+					}
+				}
+
+				class Dog extends Animal {
+					function constructor(legs) {
+						this.legs = legs * 2
+					}
+				}
+
+				d = Dog.new(4)
+				d.legs
+			`,
+			expected: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluate(tt.input)
+			isNumberObject(t, result, tt.expected)
+		})
+	}
+}
+
 func TestThisOutsideClass(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/object/class.go
+++ b/object/class.go
@@ -31,12 +31,19 @@ func (class *Class) Method(method string, args []Object) (Object, bool) {
 	case "new":
 		instance := &Instance{Class: class, Environment: NewEnclosedEnvironment(class.Environment)}
 
-		if ok := instance.Environment.Has("constructor"); ok {
-			result := instance.Call("constructor", args, class.Name.Token)
+		// Check for constructor in class and superclass chain
+		currentClass := class
+		for currentClass != nil {
+			if constructor, ok := currentClass.Environment.Get("constructor"); ok {
+				result := instance.callMethod(constructor.(*Function), args, class.Name.Token)
 
-			if result != nil && result.Type() == ERROR {
-				return result, false
+				if result != nil && result.Type() == ERROR {
+					return result, false
+				}
+
+				break
 			}
+			currentClass = currentClass.Super
 		}
 
 		return instance, true

--- a/object/instance.go
+++ b/object/instance.go
@@ -32,14 +32,18 @@ func (instance *Instance) Method(method string, args []Object) (Object, bool) {
 func (instance *Instance) Call(name string, arguments []Object, tok token.Token) Object {
 	if function, ok := instance.Environment.Get(name); ok {
 		if method, ok := function.(*Function); ok {
-			methodEnvironment := createMethodEnvironment(method, arguments)
-			methodScope := &Scope{Self: instance, Environment: methodEnvironment}
-
-			return evaluator(method.Body, methodScope)
+			return instance.callMethod(method, arguments, tok)
 		}
 	}
 
 	return NewError("%d:%d: runtime error: unknown method '%s' on class %s", tok.Line, tok.Column, name, instance.Class.Name.Value)
+}
+
+func (instance *Instance) callMethod(method *Function, arguments []Object, tok token.Token) Object {
+	methodEnvironment := createMethodEnvironment(method, arguments)
+	methodScope := &Scope{Self: instance, Environment: methodEnvironment}
+
+	return evaluator(method.Body, methodScope)
 }
 
 func createMethodEnvironment(method *Function, arguments []Object) *Environment {


### PR DESCRIPTION
## What does this implement or fix?

### Fixed
- Fixed parent constructor now called when child class has no constructor
- Fixed grandparent constructor now called when child and parent have no constructor

### Changed
- Refactored `Instance.Call` to extract `callMethod` helper for direct function invocation