### PR TITLE
Fix 10 confirmed bugs across evaluator, object, scanner, and library

### DIFF
--- a/evaluator/assign.go
+++ b/evaluator/assign.go
@@ -22,9 +22,7 @@ func evaluateAssign(node *ast.Assign, scope *object.Scope) object.Object {
 		return evaluatePropertyAssignment(assignment, value, scope)
 	}
 
-	object.NewError("%d:%d:%s: runtime error: cannot assign variable to a %T", node.Token.Line, node.Token.Column, node.Token.File, node.Name)
-
-	return nil
+	return object.NewError("%d:%d:%s: runtime error: cannot assign variable to a %T", node.Token.Line, node.Token.Column, node.Token.File, node.Name)
 }
 
 func evaluateIdentifierAssignment(node *ast.Identifier, value object.Object, scope *object.Scope) object.Object {
@@ -44,7 +42,11 @@ func evaluateIndexAssignment(node *ast.Index, assignmentValue object.Object, sco
 
 	switch obj := left.(type) {
 	case *object.List:
-		idx := int(index.(*object.Number).Int64())
+		numIdx, ok := index.(*object.Number)
+		if !ok {
+			return object.NewError("%d:%d:%s: runtime error: list index must be a number, got %s", node.Token.Line, node.Token.Column, node.Token.File, index.Type())
+		}
+		idx := int(numIdx.Int64())
 		elements := obj.Elements
 
 		if idx < 0 {

--- a/evaluator/compound.go
+++ b/evaluator/compound.go
@@ -15,7 +15,20 @@ func evaluateCompound(node *ast.Compound, scope *object.Scope) object.Object {
 
 	value := evaluateInfix(infix, scope)
 
-	scope.Environment.Set(node.Left.(*ast.Identifier).Value, value)
+	if isError(value) {
+		return value
+	}
+
+	switch target := node.Left.(type) {
+	case *ast.Identifier:
+		scope.Environment.Set(target.Value, value)
+	case *ast.Index:
+		return evaluateIndexAssignment(target, value, scope)
+	case *ast.Property:
+		return evaluatePropertyAssignment(target, value, scope)
+	default:
+		return newError("%d:%d:%s: runtime error: invalid compound assignment target: %T", node.Token.Line, node.Token.Column, node.Token.File, node.Left)
+	}
 
 	return nil
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -111,10 +111,10 @@ func isError(obj object.Object) bool {
 	return false
 }
 
-// isTerminator determines if the referenced object is an error, break, or continue.
+// isTerminator determines if the referenced object is an error, break, continue, or return.
 func isTerminator(obj object.Object) bool {
 	if obj != nil {
-		return obj.Type() == object.ERROR || obj.Type() == object.BREAK || obj.Type() == object.CONTINUE
+		return obj.Type() == object.ERROR || obj.Type() == object.BREAK || obj.Type() == object.CONTINUE || obj.Type() == object.RETURN
 	}
 
 	return false

--- a/evaluator/for.go
+++ b/evaluator/for.go
@@ -39,6 +39,8 @@ func evaluateFor(node *ast.For, scope *object.Scope) object.Object {
 				switch val := err.(type) {
 				case *object.Error:
 					return val
+				case *object.Return:
+					return val
 				case *object.Continue:
 					//
 				case *object.Break:

--- a/evaluator/for_in.go
+++ b/evaluator/for_in.go
@@ -41,6 +41,8 @@ func evaluateForIn(node *ast.ForIn, scope *object.Scope) object.Object {
 				switch val := block.(type) {
 				case *object.Error:
 					return val
+				case *object.Return:
+					return val
 				case *object.Continue:
 					//
 				case *object.Break:
@@ -60,6 +62,8 @@ func evaluateForIn(node *ast.ForIn, scope *object.Scope) object.Object {
 			if isTerminator(block) {
 				switch val := block.(type) {
 				case *object.Error:
+					return val
+				case *object.Return:
 					return val
 				case *object.Continue:
 					//

--- a/evaluator/method.go
+++ b/evaluator/method.go
@@ -74,10 +74,16 @@ func evaluateInstanceMethod(node *ast.Method, receiver *object.Instance, name st
 		}
 	}
 
-	// if we dont have a method, check for a trait
+	// if we dont have a method, check for a trait up the superclass chain
 	if method == nil {
-		for _, trait := range receiver.Class.Traits {
-			method, ok = trait.Environment.Get(name)
+		for c := receiver.Class; c != nil; c = c.Super {
+			for _, trait := range c.Traits {
+				method, ok = trait.Environment.Get(name)
+
+				if ok {
+					break
+				}
+			}
 
 			if ok {
 				break

--- a/evaluator/number.go
+++ b/evaluator/number.go
@@ -24,8 +24,14 @@ func evaluateNumberInfix(node *ast.Infix, left object.Object, right object.Objec
 	case "*":
 		return leftNum.Mul(rightNum)
 	case "/":
+		if rightNum.IsZero() {
+			return newError("%d:%d:%s: runtime error: division by zero", node.Token.Line, node.Token.Column, node.Token.File)
+		}
 		return leftNum.Div(rightNum)
 	case "%":
+		if rightNum.IsZero() {
+			return newError("%d:%d:%s: runtime error: division by zero", node.Token.Line, node.Token.Column, node.Token.File)
+		}
 		return leftNum.Mod(rightNum)
 	case "<":
 		return toBooleanValue(leftNum.LessThan(rightNum))

--- a/evaluator/while.go
+++ b/evaluator/while.go
@@ -20,6 +20,8 @@ func evaluateWhile(node *ast.While, scope *object.Scope) object.Object {
 				switch val := evaluated.(type) {
 				case *object.Error:
 					return val
+				case *object.Return:
+					return val
 				case *object.Continue:
 					//
 				case *object.Break:

--- a/library/modules/math.go
+++ b/library/modules/math.go
@@ -135,7 +135,7 @@ func mathTan(scope *object.Scope, tok token.Token, args ...object.Object) object
 // mathMax returns the largest number of the referenced numbers.
 func mathMax(scope *object.Scope, tok token.Token, args ...object.Object) object.Object {
 	if len(args) < 2 {
-		panic("math.max requires at least two arguments")
+		return object.NewError("%d:%d:%s: runtime error: math.max requires at least two arguments", tok.Line, tok.Column, tok.File)
 	}
 
 	if args[0].Type() != object.NUMBER {
@@ -159,7 +159,7 @@ func mathMax(scope *object.Scope, tok token.Token, args ...object.Object) object
 // mathMin returns the smallest number of the referenced numbers.
 func mathMin(scope *object.Scope, tok token.Token, args ...object.Object) object.Object {
 	if len(args) < 2 {
-		panic("math.min requires at least two arguments")
+		return object.NewError("%d:%d:%s: runtime error: math.min requires at least two arguments", tok.Line, tok.Column, tok.File)
 	}
 
 	if args[0].Type() != object.NUMBER {

--- a/object/list.go
+++ b/object/list.go
@@ -62,6 +62,9 @@ func (list *List) Method(method string, args []Object) (Object, bool) {
 // Object methods
 
 func (list *List) first(args []Object) (Object, bool) {
+	if len(list.Elements) == 0 {
+		return &Null{}, true
+	}
 	return list.Elements[0], true
 }
 
@@ -80,6 +83,9 @@ func (list *List) join(args []Object) (Object, bool) {
 func (list *List) last(args []Object) (Object, bool) {
 	length := len(list.Elements)
 
+	if length == 0 {
+		return &Null{}, true
+	}
 	return list.Elements[length-1], true
 }
 

--- a/object/string.go
+++ b/object/string.go
@@ -84,7 +84,7 @@ func (str *String) find(args []Object) (Object, bool) {
 	found := re.FindStringSubmatch(args[0].(*String).Value)
 
 	if len(found) > 0 {
-		return &String{Value: found[1]}, true
+		return &String{Value: found[0]}, true
 	}
 
 	return &String{}, true

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -197,11 +197,10 @@ func (scanner *Scanner) ScanToken() token.Token {
 	return scannedToken
 }
 
-// scanString consumes characters until it hits either the closing or end of
-// file. If we run to the end of the file without a closing ", we report an
-// error.
+// scanString consumes characters until it hits either the closing quote or end
+// of file, processing backslash escape sequences along the way.
 func (scanner *Scanner) scanString(closing rune) string {
-	position := scanner.position + 1
+	var result []rune
 
 	for {
 		scanner.readCharacter()
@@ -209,9 +208,33 @@ func (scanner *Scanner) scanString(closing rune) string {
 		if scanner.character == closing || scanner.isAtEnd() {
 			break
 		}
+
+		if scanner.character == '\\' {
+			scanner.readCharacter()
+			switch scanner.character {
+			case 'n':
+				result = append(result, '\n')
+			case 't':
+				result = append(result, '\t')
+			case 'r':
+				result = append(result, '\r')
+			case '\\':
+				result = append(result, '\\')
+			case '"':
+				result = append(result, '"')
+			case '\'':
+				result = append(result, '\'')
+			default:
+				result = append(result, '\\')
+				result = append(result, scanner.character)
+			}
+			continue
+		}
+
+		result = append(result, scanner.character)
 	}
 
-	return string(scanner.source[position:scanner.position])
+	return string(result)
 }
 
 // scanNumber consumes all digits for the integer part of the literal, and then


### PR DESCRIPTION
- return inside for/for-in/while loops was silently swallowed: isTerminator
  did not include RETURN, so *object.Return fell through and iteration
  continued instead of propagating the return value up to the function call

- compound assignment (+=, -=, etc.) panicked on index/property LHS because
  evaluateCompound unconditionally cast node.Left to *ast.Identifier; now
  delegates to evaluateIndexAssignment / evaluatePropertyAssignment

- evaluateAssign dropped the error for unrecognised assignment targets by
  calling object.NewError without returning it

- list index assignment panicked on non-number index (e.g. list["x"] = 1)
  due to unchecked type assertion; now returns a runtime error

- division and modulo by zero: integer % 0 caused a Go runtime panic;
  float division silently produced +Inf; both now return a runtime error

- string.find() used found[1] (first capture group) instead of found[0]
  (full match), panicking on regexes with no capture groups

- list.first() and list.last() panicked with index out of range on empty
  lists; they now return null consistent with other list methods

- scanner.scanString did not process backslash escape sequences, so \n \t
  \r \\ \" \' were stored as two-character literals in string tokens

- math.max and math.min called panic() on bad arity instead of returning
  a structured runtime error object

- trait method lookup only checked receiver.Class.Traits; now walks the
  full superclass chain so traits on parent classes are visible to children

https://claude.ai/code/session_0136eEhe68sB3Mi22WwDLhrB